### PR TITLE
Fix broken link for Japanese book

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a [community fork](https://github.com/purescript-contri
 
 If you enjoyed the book or found it useful, please consider buying a copy of [the original on Leanpub](https://leanpub.com/purescript).
 
-Translations: [日本語 (Japanese)](https://gemmaro.github.io/purescript-book/)
+Translations: [日本語 (Japanese)](https://purs-jp.github.io/purescript-book/)
 
 ## Status
 


### PR DESCRIPTION
I've fixed a broken link for Japanese book.
It seems to have moved:
from: https://gemmaro.github.io/purescript-book/
to: https://purs-jp.github.io/purescript-book/

I've also submitted a PR to the original repository.
https://github.com/purescript-contrib/purescript-book/pull/479