### PR TITLE
Fix broken link for Japanese book

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -10,10 +10,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
+        uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: 'latest'
 
@@ -31,7 +31,7 @@ jobs:
       - run: mdbook build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: github.ref == 'refs/heads/ja'
         # if: github.ref == 'refs/heads/master'
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
 
       - name: Cache PureScript dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-spago-${{ hashFiles('**/*.dhall') }}
           path: |
@@ -24,12 +24,12 @@ jobs:
             exercises/*/output
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: "14.x"
+          node-version: "24.x"
 
       - name: Cache NPM dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a [community fork](https://github.com/purescript-contri
 
 If you enjoyed the book or found it useful, please consider buying a copy of [the original on Leanpub](https://leanpub.com/purescript).
 
-Translations: [日本語 (Japanese)](https://gemmaro.github.io/purescript-book/)
+Translations: [日本語 (Japanese)](https://purs-jp.github.io/purescript-book/)
 
 ## Status
 

--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Phil Freeman"]
 language = "ja"
-multilingual = false
 src = "text-ja"
 title = "実例によるPureScript"
 

--- a/text-ja/index.md
+++ b/text-ja/index.md
@@ -8,7 +8,7 @@ PureScriptのエコシステムの最新の機能を紹介すべく書き直さ�
 
 本書をお楽しみいただき、お役立ちいただけましたら、[Leanpubの原書](https://leanpub.com/purescript)の購入をご検討ください。
 
-翻訳：[日本語（本訳）](https://gemmaro.github.io/purescript-book/)
+翻訳：[日本語（本訳）](https://purs-jp.github.io/purescript-book/)
 
 ## 現状
 

--- a/translation/po/all.pot
+++ b/translation/po/all.pot
@@ -142,7 +142,7 @@ msgstr ""
 #. type: Plain text
 #: ../README.md:8
 #, markdown-text
-msgid "Translations: [日本語 (Japanese)](https://gemmaro.github.io/purescript-book/)"
+msgid "Translations: [日本語 (Japanese)](https://purs-jp.github.io/purescript-book/)"
 msgstr ""
 
 #. type: Title ##

--- a/translation/po/ja.po
+++ b/translation/po/ja.po
@@ -142,8 +142,8 @@ msgstr ""
 #. type: Plain text
 #: ../README.md:8
 msgid ""
-"Translations: [日本語 (Japanese)](https://gemmaro.github.io/purescript-book/)"
-msgstr "翻訳：[日本語（本訳）](https://gemmaro.github.io/purescript-book/)"
+"Translations: [日本語 (Japanese)](https://purs-jp.github.io/purescript-book/)"
+msgstr "翻訳：[日本語（本訳）](https://purs-jp.github.io/purescript-book/)"
 
 #. type: Title ##
 #: ../README.md:9


### PR DESCRIPTION
I've fixed a broken link for Japanese book.
It seems to have moved:
from: https://gemmaro.github.io/purescript-book/
to: https://purs-jp.github.io/purescript-book/

I've also submitted a PR to the original repository.
https://github.com/purescript-contrib/purescript-book/pull/479