### PR TITLE
Fix deploy error

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -6,6 +6,9 @@ on:
     # branches: [master]
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The last deployment failed. It might be a permissions issue, I guess.
https://github.com/purs-jp/purescript-book/actions/runs/22138947529

Refs: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/