### PR TITLE
Improve deploy action

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -6,19 +6,30 @@ on:
     # branches: [master]
   pull_request:
 
+  workflow_dispatch:
+
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: 0.5.2
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v2
-        with:
-          mdbook-version: 'latest'
+      - name: Install mdBook
+        run: |
+          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
+          rustup update
+          cargo install --version ${MDBOOK_VERSION} mdbook
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
@@ -31,13 +42,27 @@ jobs:
           echo -e "PureScript v$version\n" >> README.md
           echo -e "Published on $today" >> README.md
 
-      - run: mdbook build
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        if: github.ref == 'refs/heads/ja'
-        # if: github.ref == 'refs/heads/master'
+      - name: Build with mdBook
+        run: mdbook build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book
-          # cname: book.purescript.org
+          path: ./book
+
+  deploy:
+    if: github.ref == 'refs/heads/ja'
+    # if: github.ref == 'refs/heads/master'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/book.toml
+++ b/book.toml
@@ -5,5 +5,5 @@ src = "text-ja"
 title = "実例によるPureScript"
 
 [output.html]
-git-repository-url = "https://github.com/gemmaro/purescript-book"
+git-repository-url = "https://github.com/purs-jp/purescript-book"
 mathjax-support = true

--- a/translation/po/ja.po
+++ b/translation/po/ja.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: com.github.gemmaro.purescript-book.v0.1.0\n"
+"Project-Id-Version: com.github.purs-jp.purescript-book.v0.1.0\n"
 "POT-Creation-Date: 2024-08-05 08:18+0900\n"
 "PO-Revision-Date: 2024-08-05 08:25+0900\n"
 "Last-Translator: gemmaro <gemmaro.dev@gmail.com>\n"


### PR DESCRIPTION
## What
- The actions used for building mdbook and deploying to GitHub Pages have been changed from community-maintained ones to official ones. According to this comment https://github.com/purs-jp/purescript-book/pull/4#issuecomment-3923393739
- GitHub URL has been changed to new one.

## Why
This decision was made in consideration of deployment health and support systems in the future.

## Remarks

I've already confirmed if this workflow succeed in my fork. Pages are already unpublished.
https://github.com/daaa1k/purescript-book/actions/runs/22166552920

> [!IMPORTANT]
> Some settings need to be changed. Please modify the settings according to the figure below before merging this PR.

1. Set GitHub Pages Source as `GitHub Actions`
   <img width="731" height="567" alt="image" src="https://github.com/user-attachments/assets/d4698d70-708a-4b81-aeac-90184c42846d" />


2. Add `ja` as github-pages deployment branch
   <img width="1142" height="778" alt="image" src="https://github.com/user-attachments/assets/5de0cdeb-ca0b-487d-ac56-d88066fe45e3" />
